### PR TITLE
API: Add a c-function zeros_like based on calloc

### DIFF
--- a/numpy/core/code_generators/numpy_api.py
+++ b/numpy/core/code_generators/numpy_api.py
@@ -350,6 +350,8 @@ multiarray_funcs_api = {
     'PyArray_ResolveWritebackIfCopy':       (302,),
     'PyArray_SetWritebackIfCopyBase':       (303,),
     # End 1.14 API
+    # End 1.15 API
+    'PyArray_NewZerosLikeArray':            (304, StealRef(3), NonNull(1)),
 }
 
 ufunc_types_api = {

--- a/numpy/core/multiarray.py
+++ b/numpy/core/multiarray.py
@@ -33,5 +33,4 @@ __all__ = [
     'set_datetimeparse_function', 'set_legacy_print_mode', 'set_numeric_ops',
     'set_string_function', 'set_typeDict', 'shares_memory', 'test_interrupt',
     'tracemalloc_domain', 'typeinfo', 'unpackbits', 'unravel_index', 'vdot',
-    'where', 'zeros']
-
+    'where', 'zeros', 'zeros_like']

--- a/numpy/core/numeric.py
+++ b/numpy/core/numeric.py
@@ -24,6 +24,7 @@ from .multiarray import (
     min_scalar_type, ndarray, nditer, nested_iters, promote_types,
     putmask, result_type, set_numeric_ops, shares_memory, vdot, where,
     zeros, normalize_axis_index)
+from .multiarray import zeros_like as _zeros_like
 if sys.version_info[0] < 3:
     from .multiarray import newbuffer, getbuffer
 
@@ -158,10 +159,10 @@ def zeros_like(a, dtype=None, order='K', subok=True):
     array([ 0.,  0.,  0.])
 
     """
-    res = empty_like(a, dtype=dtype, order=order, subok=subok)
+    res = _zeros_like(a, dtype=dtype, order=order, subok=subok)
     # needed instead of a 0 to get same result as zeros for for string dtypes
-    z = zeros(1, dtype=res.dtype)
-    multiarray.copyto(res, z, casting='unsafe')
+    # z = zeros(1, dtype=res.dtype)
+    # multiarray.copyto(res, z, casting='unsafe')
     return res
 
 

--- a/numpy/core/src/multiarray/multiarraymodule.c
+++ b/numpy/core/src/multiarray/multiarraymodule.c
@@ -1861,6 +1861,37 @@ fail:
     return NULL;
 }
 
+static PyObject *
+array_zeros_like(PyObject *NPY_UNUSED(ignored), PyObject *args, PyObject *kwds)
+{
+
+    static char *kwlist[] = {"prototype","dtype","order","subok",NULL};
+    PyArrayObject *prototype = NULL;
+    PyArray_Descr *dtype = NULL;
+    NPY_ORDER order = NPY_KEEPORDER;
+    PyArrayObject *ret = NULL;
+    int subok = 1;
+
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O&|O&O&i:zero_like", kwlist,
+                &PyArray_Converter, &prototype,
+                &PyArray_DescrConverter2, &dtype,
+                &PyArray_OrderConverter, &order,
+                &subok)) {
+        goto fail;
+    }
+    /* steals the reference to dtype if it's not NULL */
+    ret = (PyArrayObject *)PyArray_NewZerosLikeArray(prototype,
+                                            order, dtype, subok);
+    Py_DECREF(prototype);
+
+    return (PyObject *)ret;
+
+fail:
+    Py_XDECREF(prototype);
+    Py_XDECREF(dtype);
+    return NULL;
+}
+
 /*
  * This function is needed for supporting Pickles of
  * numpy scalar objects.
@@ -4388,6 +4419,9 @@ static struct PyMethodDef array_module_methods[] = {
         METH_VARARGS, NULL},
     {"_add_newdoc_ufunc", (PyCFunction)add_newdoc_ufunc,
         METH_VARARGS, NULL},
+    {"zeros_like",
+        (PyCFunction)array_zeros_like,
+        METH_VARARGS|METH_KEYWORDS, NULL},
     {NULL, NULL, 0, NULL}                /* sentinel */
 };
 


### PR DESCRIPTION
TODO:
- [x] Send on mailing list.
- [ ] Merge code paths for empty_like and zeros_like
- [ ] Move zeros_like to a pure-c implementation.
- [ ] Test the C API function independently of the Python.